### PR TITLE
move autoaccept logic to application

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Features:
 - a sample demonstrating the use of this to build a federated multi-user conference (in full-mesh mode). When [hark](https://github.com/latentflip/hark) is available, the local audio volume is visualized (in Chrome M29+).
 
 Events:
-- callincoming.jingle (sid)
+- callincoming.jingle (sid) -- you should accept the session here
 - callterminated.jingle (sid)
 - nostuncandidates.jingle (sid)
 - remotestreamadded.jingle (event, sid)

--- a/examples/muc.js
+++ b/examples/muc.js
@@ -198,6 +198,9 @@ function onMediaFailure() {
 
 function onCallIncoming(event, sid) {
     setStatus('incoming call' + sid);
+    var sess = connection.jingle.sessions[sid];
+    sess.sendAnswer();
+    sess.accept();
 }
 
 function onCallActive(event, videoelem, sid) {

--- a/strophe.jingle.session.js
+++ b/strophe.jingle.session.js
@@ -578,14 +578,16 @@ JingleSession.prototype.sendTerminate = function(reason, text) {
         term.up().c('text').t(text);
     
     this.connection.sendIQ(term,
-                   function() {
-                   console.log('terminate ack');
-                   obj.peerconnection.close();
-                   obj.peerconnection = null;
-                   obj.terminate();
-                   },
-                   function() { console.log('terminate error'); },
-                   10000);
+        function() {
+            console.log('terminate ack');
+            obj.peerconnection.close();
+            obj.peerconnection = null;
+            obj.terminate();
+        },
+        function() { 
+            console.log('terminate error'); 
+        },
+    10000);
 };
 
 JingleSession.prototype.sendMute = function(muted, content) {


### PR DESCRIPTION
this commit moves autoaccept out of the library, .sendAnswer() and .accept() in callback.
